### PR TITLE
Algae sim fixes

### DIFF
--- a/smarc_stonefish_worlds/config/algae_world_small.yaml
+++ b/smarc_stonefish_worlds/config/algae_world_small.yaml
@@ -1,17 +1,19 @@
 environment_file: "$(find smarc_stonefish_worlds)/data/algae/algae_env_small.scn"
 latitude: "58.250833"
 longitude: "11.450283"
-anchoring_buoy_rope: "$(find smarc_stonefish_worlds)/data/algae/components/anchoring_chain.obj"
-a0_buoy: "$(find smarc_stonefish_worlds)/data/algae/components/a0_buoy.obj"
-rope: "$(find smarc_stonefish_worlds)/data/algae/components/a0_buoy_ropes_small_farm.obj"
 algae_texture_dir: "$(find smarc_stonefish_worlds)/data/algae/textures"
-algae_row1: "$(find smarc_stonefish_worlds)/data/algae/components/algae_row1_small_farm.obj"
-algae_row2: "$(find smarc_stonefish_worlds)/data/algae/components/algae_row2_small_farm.obj"
+mesh: {
+    anchoring_buoy_rope: "$(find smarc_stonefish_worlds)/data/algae/components/anchoring_chain.obj",
+    a0_buoy: "$(find smarc_stonefish_worlds)/data/algae/components/a0_buoy.obj",
+    rope: "$(find smarc_stonefish_worlds)/data/algae/components/a0_buoy_ropes_small_farm.obj",
+    algae_row1: "$(find smarc_stonefish_worlds)/data/algae/components/algae_row1_small_farm.obj",
+    algae_row2: "$(find smarc_stonefish_worlds)/data/algae/components/algae_row2_small_farm.obj"
+}
 marked_positions: {
-    buoy_corner1: {position: "4.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
-    buoy_corner2: {position: "4.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
-    buoy_corner3: {position: "14.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
-    buoy_corner4: {position: "14.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
-    buoy_mid1: {position: "9.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"},
-    buoy_mid2: {position: "9.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"}
+    buoy_corner1: {position: "4.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white", mesh: "a0_buoy"},
+    buoy_corner2: {position: "4.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white", mesh: "a0_buoy"},
+    buoy_corner3: {position: "14.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white", mesh: "a0_buoy"},
+    buoy_corner4: {position: "14.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white", mesh: "a0_buoy"},
+    buoy_mid1: {position: "9.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "red", mesh: "a0_buoy"},
+    buoy_mid2: {position: "9.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "red", mesh: "a0_buoy"}
 }

--- a/smarc_stonefish_worlds/config/algae_world_small.yaml
+++ b/smarc_stonefish_worlds/config/algae_world_small.yaml
@@ -8,10 +8,10 @@ algae_texture_dir: "$(find smarc_stonefish_worlds)/data/algae/textures"
 algae_row1: "$(find smarc_stonefish_worlds)/data/algae/components/algae_row1_small_farm.obj"
 algae_row2: "$(find smarc_stonefish_worlds)/data/algae/components/algae_row2_small_farm.obj"
 marked_positions: {
-    buoy_corner1: {position: "4.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"},
-    buoy_corner2: {position: "4.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"},
-    buoy_corner3: {position: "14.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"},
-    buoy_corner4: {position: "14.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"},
-    buoy_mid1: {position: "9.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
-    buoy_mid2: {position: "9.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"}
+    buoy_corner1: {position: "4.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
+    buoy_corner2: {position: "4.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
+    buoy_corner3: {position: "14.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
+    buoy_corner4: {position: "14.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "white"},
+    buoy_mid1: {position: "9.00 -5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"},
+    buoy_mid2: {position: "9.00 5.00 0.00", orientation: "0.00 0.00 0.00", color: "red"}
 }

--- a/smarc_stonefish_worlds/data/algae/algae_env_small.scn
+++ b/smarc_stonefish_worlds/data/algae/algae_env_small.scn
@@ -49,7 +49,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="4.00 0.00 0.00" rpy="0.00 0.00 0.00"/>
 	<physical>
-		<mesh filename="$(param rope)" scale="1.0"/>
+		<mesh filename="$(param mesh/rope)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -61,7 +61,7 @@
 	<material name="Neutral"/>
     <world_transform xyz="$(param marked_positions/buoy_corner1/position)" rpy="$(param marked_positions/buoy_corner1/orientation)"/>
 	<physical>
-		<mesh filename="$(param a0_buoy)" scale="1.0"/>
+		<mesh filename="$(param mesh/a0_buoy)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -71,7 +71,7 @@
 	<material name="Neutral"/>
     <world_transform xyz="$(param marked_positions/buoy_corner2/position)" rpy="$(param marked_positions/buoy_corner1/orientation)"/>
 	<physical>
-		<mesh filename="$(param a0_buoy)" scale="1.0"/>
+		<mesh filename="$(param mesh/a0_buoy)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -81,7 +81,7 @@
 	<material name="Neutral"/>
     <world_transform xyz="$(param marked_positions/buoy_corner3/position)" rpy="$(param marked_positions/buoy_corner1/orientation)"/>
 	<physical>
-		<mesh filename="$(param a0_buoy)" scale="1.0"/>
+		<mesh filename="$(param mesh/a0_buoy)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -91,7 +91,7 @@
 	<material name="Neutral"/>
     <world_transform xyz="$(param marked_positions/buoy_corner4/position)" rpy="$(param marked_positions/buoy_corner1/orientation)"/>
 	<physical>
-		<mesh filename="$(param a0_buoy)" scale="1.0"/>
+		<mesh filename="$(param mesh/a0_buoy)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -103,7 +103,7 @@
 	<material name="Neutral"/>
     <world_transform xyz="$(param marked_positions/buoy_mid1/position)" rpy="$(param marked_positions/buoy_mid1/orientation)"/>
 	<physical>
-		<mesh filename="$(param a0_buoy)" scale="1.0"/>
+		<mesh filename="$(param mesh/a0_buoy)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -113,7 +113,7 @@
 	<material name="Neutral"/>
     <world_transform xyz="$(param marked_positions/buoy_mid2/position)" rpy="$(param marked_positions/buoy_mid2/orientation)"/>
 	<physical>
-		<mesh filename="$(param a0_buoy)" scale="1.0"/>
+		<mesh filename="$(param mesh/a0_buoy)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -125,7 +125,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="4.00 -5.00 0.00" rpy="0.00 0.00 3.14"/>
 	<physical>
-		<mesh filename="$(param anchoring_buoy_rope)" scale="1.0"/>
+        <mesh filename="$(param mesh/anchoring_buoy_rope)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -135,7 +135,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="4.00 5.00 0.00" rpy="0.00 0.00 0.00"/>
 	<physical>
-		<mesh filename="$(param anchoring_buoy_rope)" scale="1.0"/>
+        <mesh filename="$(param mesh/anchoring_buoy_rope)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -145,7 +145,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="14.00 -5.00 0.00" rpy="0.00 0.00 3.14"/>
 	<physical>
-		<mesh filename="$(param anchoring_buoy_rope)" scale="1.0"/>
+		<mesh filename="$(param mesh/anchoring_buoy_rope)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -155,7 +155,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="14.00 5.00 0.00" rpy="0.00 0.00 0.00"/>
 	<physical>
-		<mesh filename="$(param anchoring_buoy_rope)" scale="1.0"/>
+		<mesh filename="$(param mesh/anchoring_buoy_rope)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -167,7 +167,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="4.00 0.00 0.00" rpy="0.00 0.00 0.00"/>
 	<physical>
-        <mesh filename="$(param algae_row1)" scale="1.0"/>
+        <mesh filename="$(param mesh/algae_row1)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>
@@ -177,7 +177,7 @@
 	<material name="Neutral"/>
 	<world_transform xyz="4.00 10.00 0.00" rpy="0.00 0.00 0.00"/>
 	<physical>
-		<mesh filename="$(param algae_row2)" scale="1.0"/>
+		<mesh filename="$(param mesh/algae_row2)" scale="1.0"/>
 		<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
 	</physical>
 </static>

--- a/smarc_stonefish_worlds/launch/stonefish.launch
+++ b/smarc_stonefish_worlds/launch/stonefish.launch
@@ -2,16 +2,16 @@
 <launch>
 
     <!-- These are the arguments you need to care about -->
-    <arg name="world_config_file" default="$(find smarc_stonefish_worlds)/config/biograd_world.yaml"/>
+    <arg name="world_config_file" default="$(find smarc_stonefish_worlds)/config/algae_world_small.yaml"/>
     <arg name="robot_config_file" default="$(find sam_stonefish_sim)/config/sam_no_payload_sensors.yaml"/>
     <arg name="scenario_description" default="$(find smarc_stonefish_worlds)/data/scenarios/default.scn"/>
     <arg name="simulate_dr" default="true"/>
     <arg name="map_frame" value="map" if="$(arg simulate_dr)"/>
     <arg name="map_frame" value="gt/map" unless="$(arg simulate_dr)"/>
 
-    <!-- UTM Zone for Biograd simulation -->
-    <arg name="utm_zone" default="33"/>
-    <arg name="utm_band" default="T"/>
+    <!-- UTM Zone for Kristineberg simulation -->
+    <arg name="utm_zone" default="32"/>
+    <arg name="utm_band" default="V"/>
 
     <!-- These are more for fine-tuning -->
     <arg name="simulation_data" default="$(find smarc_stonefish_worlds)/data"/> <!-- path to the data directory -->


### PR DESCRIPTION
- Set default stonefish simulation environment to `algae_farm_small`
- Change colors of the buoys (reverse the colors of middle and corner buoys)
- Modify structure of the environment file. Put meshes into a dict named `mesh` and add `marked_positions` dict. 